### PR TITLE
Change in explanation of CodeDeploy's 5-minute timeout logic to avoid confusion with event lifecycle timeouts

### DIFF
--- a/doc_source/troubleshooting-auto-scaling.md
+++ b/doc_source/troubleshooting-auto-scaling.md
@@ -71,7 +71,7 @@ To address this issue:
 
 As a best practice, you should associate only one deployment group with each Auto Scaling group\. 
 
-This is because if Auto Scaling scales up an instance that has hooks associated with multiple deployment groups, it sends notifications for all of the hooks at once\. This causes multiple deployments to each instance to begin at the same time\. When multiple deployments send commands to the AWS CodeDeploy agent at the same time, the five\-minute limit in the AWS CodeDeploy timeout logic may be exceeded\. \(AWS CodeDeploy logic considers a deployment to have failed if its steps are not complete within five minutes, even if a deployment process is otherwise running as expected\.\) 
+This is because if Auto Scaling scales up an instance that has hooks associated with multiple deployment groups, it sends notifications for all of the hooks at once\. This causes multiple deployments to each instance to begin at the same time\. When multiple deployments send commands to the AWS CodeDeploy agent at the same time, the five\-minute limit in the AWS CodeDeploy timeout logic may be exceeded\. \(AWS CodeDeploy's timeout logic expects any deployment to start processing lifecycle events on the instance within five minutes of having been started\.\) 
 
 It's not possible to control the order in which deployments occur if more than one deployment attempts to run at the same time\. 
 

--- a/doc_source/troubleshooting-general.md
+++ b/doc_source/troubleshooting-general.md
@@ -83,7 +83,7 @@ If you rely on an IAM instance profile or a service role that was created as par
 
 As a best practice, you should avoid situations that would result in more than one attempted deployment to an Amazon EC2 instance at the same time\. In cases where commands from different deployments compete to run on a single instance, the deployments can time out and fail for the following reasons:
 
-+ AWS CodeDeploy's timeout logic expects all of the steps in a deployment process to be completed in five minutes or less\. 
++ AWS CodeDeploy's timeout logic expects any deployment to start processing lifecycle events on the instance within five minutes of having been started\.
 
 + The AWS CodeDeploy agent can process only one deployment command at a time\. 
 


### PR DESCRIPTION
*Description of changes:*
Currently, the description of CodeDeploy's 5-minute timeout logic can a little confusing. The statement "_expects all of the steps in a deployment process to be completed in five minutes or less_" can be seen as directly incompatible with the use of event lifecycle timeouts set to values greater than 5 minutes. The proposed change describes the same timeout limit, but from the angle of the deployment waiting on the queue rather than the running one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
