### PR TITLE
Removed incorrect "secret key" statement on Step 3

### DIFF
--- a/doc_source/register-on-premises-instance-iam-session-arn.md
+++ b/doc_source/register-on-premises-instance-iam-session-arn.md
@@ -133,7 +133,7 @@ Add a configuration file to the on\-premises instance, using root or administrat
    ```
 
    Where:
-   + *iam\-session\-arn* is the IAM session secret key ARN you noted in [Step 2: Generate Temporary Credentials for an Individual Instance Using AWS STS](#register-on-premises-instance-iam-session-arn-2)\. 
+   + *iam\-session\-arn* is the IAM session ARN you noted in [Step 2: Generate Temporary Credentials for an Individual Instance Using AWS STS](#register-on-premises-instance-iam-session-arn-2)\. 
    + *credentials\-file* is the location of the credentials file for the temporary session ARN, as noted in [Step 2: Generate Temporary Credentials for an Individual Instance Using AWS STS](#register-on-premises-instance-iam-session-arn-2)\.
    + *supported\-region* is one of the regions that AWS CodeDeploy supports, as listed in [Region and Endpoints](http://docs.aws.amazon.com/general/latest/gr/rande.html#codedeploy_region) in *AWS General Reference*\.
 


### PR DESCRIPTION
*Description of changes:*
On Step 3, the description of what "iam_session_arn" means states that it is the "IAM session secret key ARN" generated on Step 2. I believe this is incorrect, and should read "IAM session ARN" instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
