### PR TITLE
Stating Target Type limitation

### DIFF
--- a/doc_source/integrations-aws-elastic-load-balancing.md
+++ b/doc_source/integrations-aws-elastic-load-balancing.md
@@ -6,7 +6,7 @@ Classic Load Balancer
 Routes and load balances either at the transport layer \(TCP/SSL\) or the application layer \(HTTP/HTTPS\)\. It supports either EC2\-Classic or a VPC\.
 
 Application Load Balancer  
-Routes and load balances at the application layer \(HTTP/HTTPS\) and supports path\-based routing\. It can route requests to ports on each EC2 instance or container instance in your virtual private cloud \(VPC\)\.
+Routes and load balances at the application layer \(HTTP/HTTPS\) and supports path\-based routing\. It can route requests to ports on each EC2 instance or container instance in your virtual private cloud \(VPC\)\. Note: only Target Groups with Target Type = Instance are supported at this time.
 
 Network Load Balancer  
 Routes and load balances at the transport layer \(TCP/UDP Layer\-4\) based on address information extracted from the TCP packet header, not from packet content\. Network Load Balancers can handle traffic bursts, retain the source IP of the client, and use a fixed IP for the life of the load balancer\. 


### PR DESCRIPTION
*Description of changes:*
Currently CodeDeploy can only be used natively with Target Groups where Target Type = Instance. This is a suggestion for a simple statement that makes that clear.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
