### PR TITLE
Removed Yum Update

### DIFF
--- a/doc_source/codedeploy-agent-operations-install-linux.md
+++ b/doc_source/codedeploy-agent-operations-install-linux.md
@@ -3,11 +3,7 @@
 Sign in to the instance, and run the following commands, one at a time\.
 
 **Note**  
-In the fourth command, `/home/ec2-user` represents the default user name for an Amazon Linux or RHEL Amazon EC2 instance\. If your instance was created using a custom AMI, the AMI owner might have specified a different default user name\. 
-
-```
-sudo yum update
-```
+In the third command, `/home/ec2-user` represents the default user name for an Amazon Linux or RHEL Amazon EC2 instance\. If your instance was created using a custom AMI, the AMI owner might have specified a different default user name\. 
 
 ```
 sudo yum install ruby


### PR DESCRIPTION
Is there any particular reason an OS update is needed? This is less than ideal.

If this command was inteded to download the package lists from the repositories and "update" them, YUM already does this by default on Yum install. 

It does not require to "update" as APT does on Debian based distros.

"yum update" will update all the packages in the system to the latest version... 

yum update package_name
    Used to update the specified packages to the latest available version. If no packages are specified, then yum will attempt to update all installed packages. 

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-keeping_your_system_up-to-date

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
