### PR TITLE
update 18.04 installation

### DIFF
--- a/doc_source/codedeploy-agent-operations-install-ubuntu.md
+++ b/doc_source/codedeploy-agent-operations-install-ubuntu.md
@@ -16,7 +16,7 @@ On Ubuntu Server 14\.04:
   sudo apt-get install ruby2.0
   ```
 
-On Ubuntu Server 16\.04:
+On Ubuntu Server 16\.04 and 18.04:
 + 
 
   ```

--- a/doc_source/codedeploy-agent-operations-install-ubuntu.md
+++ b/doc_source/codedeploy-agent-operations-install-ubuntu.md
@@ -5,23 +5,27 @@ Sign in to the instance, and run the following commands, one at a time\.
 **Note**  
 In the fifth command, `/home/ubuntu` represents the default user name for an Ubuntu Server instance\. If your instance was created using a custom AMI, the AMI owner might have specified a different default user name\. 
 
+On Ubuntu Server 14\.04:
++ 
+
 ```
 sudo apt-get update
 ```
 
-On Ubuntu Server 14\.04:
-+ 
-
-  ```
-  sudo apt-get install ruby2.0
-  ```
+```
+sudo apt-get install ruby2.0
+```
 
 On Ubuntu Server 16\.04 and 18.04:
 + 
 
-  ```
-  sudo apt-get install ruby
-  ```
+```
+sudo apt-get update
+```
+
+```
+sudo apt-get install ruby
+```
 
 ```
 sudo apt-get install wget


### PR DESCRIPTION
do not use sudo apt-get install ruby2.0 for 18.04

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
