### PR TITLE
"Scale Out" not "Scale Up" for Horizontal Scaling

### DIFF
--- a/doc_source/tutorials-auto-scaling-group-scale-up.md
+++ b/doc_source/tutorials-auto-scaling-group-scale-up.md
@@ -3,10 +3,10 @@
 In this step, you instruct the Amazon EC2 Auto Scaling group to create an additional Amazon EC2 instance\. After Amazon EC2 Auto Scaling creates the instance, CodeDeploy deploys your revision to it\.
 
 **Topics**
-+ [To scale up the number of Amazon EC2 instances in the Amazon EC2 Auto Scaling group \(CLI\)](#tutorials-auto-scaling-group-scale-up-cli)
-+ [To scale up the number of Amazon EC2 instances in the deployment group \(console\)](#tutorials-auto-scaling-group-scale-up-console)
++ [To scale out the number of Amazon EC2 instances in the Amazon EC2 Auto Scaling group \(CLI\)](#tutorials-auto-scaling-group-scale-up-cli)
++ [To scale out the number of Amazon EC2 instances in the deployment group \(console\)](#tutorials-auto-scaling-group-scale-up-console)
 
-## To scale up the number of Amazon EC2 instances in the Amazon EC2 Auto Scaling group \(CLI\)<a name="tutorials-auto-scaling-group-scale-up-cli"></a>
+## To scale out the number of Amazon EC2 instances in the Amazon EC2 Auto Scaling group \(CLI\)<a name="tutorials-auto-scaling-group-scale-up-cli"></a>
 
 1. Call the update\-auto\-scaling\-group command to increase the Amazon EC2 instances in the Amazon EC2 Auto Scaling group named **CodeDeployDemo\-AS\-Group** from one to two\.
 
@@ -34,7 +34,7 @@ In this step, you instruct the Amazon EC2 Auto Scaling group to create an additi
 
    Do not proceed until both of the returned values show `Healthy` and `InService`\.
 
-## To scale up the number of Amazon EC2 instances in the deployment group \(console\)<a name="tutorials-auto-scaling-group-scale-up-console"></a>
+## To scale out the number of Amazon EC2 instances in the deployment group \(console\)<a name="tutorials-auto-scaling-group-scale-up-console"></a>
 
 1. In the Amazon EC2 navigation bar, under **Auto Scaling**, choose **Auto Scaling Groups**, and then choose **CodeDeployDemo\-AS\-Group**\.
 


### PR DESCRIPTION
*Issue #, if available:* Wrong technical term used

*Description of changes:*

In AWS, the phrase “Scale UP the EC2 instance” means that you have to UPGRADE (vertically scale) the instance to a higher instance type ( e.g. t3 small to t3 large). 

When you say, “Scale OUT your EC2 instances" -- it means that you have to increase (horizontally scale ) the number of EC2 instances using Auto Scaling.

On this page, there is an ambiguity in the terms used. It's using "scale UP" for a scaling operation. It should be "scale OUT" the number of EC2 instances.

All of the other AWS pages below use the correct phrase: "scale out" : 
 
https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-capacity-limits.html
https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-scaling-simple-step.html
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_NET.managing.as.html


The same format is also used in Azure documentation. I understand that "Scale UP" and "Scale OUT" seems to be synonymous but I think we should to use the most accurate terms to avoid confusion.  

Cheers,
Jon Bonso

https://www.linkedin.com/in/jonbonso/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
