### PR TITLE
Remove reference to lambda in ECS hooks docs

### DIFF
--- a/doc_source/reference-appspec-file-structure-hooks.md
+++ b/doc_source/reference-appspec-file-structure-hooks.md
@@ -75,7 +75,7 @@ Using JSON:
 
 ### Sample Lambda 'hooks' function<a name="reference-appspec-file-structure-hooks-section-structure-ecs-sample-function"></a>
 
-Use the `'hooks'` section to specify a Lambda function that CodeDeploy can call to validate a Lambda deployment\. You can use the same function or a different one for the `BeforeInstall`, `AfterInstall`, `AfterAllowTestTraffic`, `BeforeAllowTraffic`, and `AfterAllowTraffic` deployment lifecyle events\. Following completion of the validation tests, the Lambda `AfterAllowTraffic` function calls back CodeDeploy and delivers a result of `Succeeded` or `Failed`\. 
+Use the `'hooks'` section to specify a Lambda function that CodeDeploy can call to validate an ECS deployment\. You can use the same function or a different one for the `BeforeInstall`, `AfterInstall`, `AfterAllowTestTraffic`, `BeforeAllowTraffic`, and `AfterAllowTraffic` deployment lifecyle events\. Following completion of the validation tests, the Lambda `AfterAllowTraffic` function calls back CodeDeploy and delivers a result of `Succeeded` or `Failed`\. 
 
 **Important**  
 The deployment is considered to have failed if CodeDeploy is not notified by the Lambda validation function within one hour\.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* ECS section has a number of references to lambda that seemed confusing. I believe this one is definitely incorrect, also wondering about the first line in the ECS section: `An AWS Lambda hook is one Lambda function specified with a string on a new line after the name of the lifecycle event.`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
