### PR TITLE
tag:GetTags -> tag:getTagKeys, tag:getTagValues

### DIFF
--- a/doc_source/instances-on-premises-register-instance.md
+++ b/doc_source/instances-on-premises-register-instance.md
@@ -45,7 +45,8 @@ As you configure the AWS CLI \(for example, by calling the aws configure command
            "iam:ListUserPolicies",
            "iam:PutUserPolicy",
            "iam:GetUser",
-           "tag:GetTags",
+           "tag:getTagKeys",
+           "tag:getTagValues",
            "tag:GetResources"
          ],
          "Resource" : "*"


### PR DESCRIPTION
I noticed an issue when using the provided JSON policy due to `"tag:GetTags"` that results in the following error: 

```
Invalid Action: The action tag:GetTags does not exist.
```

This PR addresses this by removing `"tag:GetTags"` and replacing it with `"tag:getTagKeys"` and `"tag:getTagValues"`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
