### PR TITLE
Error parsing parameter '--launch-template' fix

### DIFF
--- a/doc_source/tutorials-auto-scaling-group-create-auto-scaling-group.md
+++ b/doc_source/tutorials-auto-scaling-group-create-auto-scaling-group.md
@@ -98,7 +98,7 @@ For a list of region name identifiers, see [Resource kit bucket names by Region]
    On local Windows machines:
 
    ```
-   aws autoscaling create-auto-scaling-group --auto-scaling-group-name CodeDeployDemo-AS-Group --launch-template CodeDeployDemo-AS-Launch-Template,Version="$Latest" --min-size 1 --max-size 1 --desired-capacity 1 --availability-zones availability-zone --tags Key=Name,Value=CodeDeployDemo,PropagateAtLaunch=true
+   aws autoscaling create-auto-scaling-group --auto-scaling-group-name CodeDeployDemo-AS-Group --launch-template LaunchTemplateName=CodeDeployDemo-AS-Launch-Template,Version="$Latest" --min-size 1 --max-size 1 --desired-capacity 1 --availability-zones availability-zone --tags Key=Name,Value=CodeDeployDemo,PropagateAtLaunch=true
    ```
 
    These commands create an Auto Scaling group named **CodeDeployDemo\-AS\-Group** based on the Amazon EC2 launch template named **CodeDeployDemo\-AS\-Launch\-Template**\. This Auto Scaling group has only one Amazon EC2 instance, and it is created in the specified Availability Zone\. Each instance in this Auto Scaling group will have the tag `Name=CodeDeployDemo`\. The tag will be used when installing the CodeDeploy agent later\.


### PR DESCRIPTION
As per the following document https://awscli.amazonaws.com/v2/documentation/api/latest/reference/autoscaling/create-auto-scaling-group.html snippet:
```
LaunchTemplateId -> (string)

The ID of the launch template. To get the template ID, use the Amazon EC2 DescribeLaunchTemplates API operation. New launch templates can be created using the Amazon EC2 CreateLaunchTemplate API.

Conditional: You must specify either a LaunchTemplateId or a LaunchTemplateName .
````

Without the proposed change the "aws autoscaling create-auto-scaling-group ..." results in:
```
Error parsing parameter '--launch-template': Expected: '=', received: ',' for input:
CodeDeployDemo-AS-Launch-Template,Version=$Latest
```

*Description of changes:*
changed a command to a working one, by providing it with a `--launch-template` parameter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
