### PR TITLE
Update Lambda runtime in SAM tutorial

### DIFF
--- a/doc_source/tutorial-lambda-sam-template.md
+++ b/doc_source/tutorial-lambda-sam-template.md
@@ -21,7 +21,7 @@ Create an AWS SAM template file that specifies the components in your infrastruc
        Type: AWS::Serverless::Function
        Properties:
          Handler: myDateTimeFunction.handler
-         Runtime: nodejs10.x
+         Runtime: nodejs16.x
    # Instructs your myDateTimeFunction is published to an alias named "live".      
          AutoPublishAlias: live
    # Grants this function permission to call lambda:InvokeFunction
@@ -61,7 +61,7 @@ Create an AWS SAM template file that specifies the components in your infrastruc
                Action: 
                  - "lambda:InvokeFunction"
                Resource: !Ref myDateTimeFunction.Version
-         Runtime: nodejs10.x
+         Runtime: nodejs16.x
    # Specifies the name of the Lambda hook function      
          FunctionName: 'CodeDeployHook_beforeAllowTraffic'
          DeploymentPreference:
@@ -92,7 +92,7 @@ Create an AWS SAM template file that specifies the components in your infrastruc
                Action: 
                  - "lambda:InvokeFunction"
                Resource: !Ref myDateTimeFunction.Version
-         Runtime: nodejs10.x
+         Runtime: nodejs16.x
    # Specifies the name of the Lambda hook function      
          FunctionName: 'CodeDeployHook_afterAllowTraffic'
          DeploymentPreference:


### PR DESCRIPTION
*Issue #, if available:*

The runtime nodejs10.x for Lambda has been deprecated [1] hence updated the sample code with the latest supported runtime.

[1] Lambda runtimes - Runtime deprecation policy - https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy

*Description of changes:*

Update the Lambda function runtime to `nodejs16.x`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
