### PR TITLE
Update troubleshooting-deployments-lambda.md

### DIFF
--- a/doc_source/troubleshooting-deployments-lambda.md
+++ b/doc_source/troubleshooting-deployments-lambda.md
@@ -13,10 +13,10 @@ In some cases, the alias of a Lambda function specified in a deployment might re
 
 1. Select the name of the Lambda function that is in your CodeDeploy deployment\.
 
-1. From **Qualifiers**, choose the alias used in your CodeDeploy deployment\.
+1. From **Aliases**, select the alias used in your CodeDeploy deployment, choose **Edit**\.
 
-1. From **Additional Version**, choose **<none>**\. This ensures the alias is not configured to shift a percentage, or weight, of traffic to more than one version\. Make a note of the version selected in **Version**\.
+1. From **Weighted alias**, choose **\<none\>**\. This ensures the alias is not configured to shift a percentage, or weight, of traffic to more than one version\. Make a note of the version selected in **Version**\.
 
-1. Choose **Save and test**\.
+1. Choose **Save**\.
 
 1. Open the CodeDeploy console and attempt a deployment of the version displayed in the drop\-down menu in step 5\.


### PR DESCRIPTION
Update the section titles and button name to reflect the current UI state.

*Issue #, if available:*
The steps listed in the troubleshooting guide don't line up exactly with the current production UI of the AWS console.

*Description of changes:*
I updated the name of the tab in Lambda from Qualifiers to Aliases as that's what the tab is currently called. I explicitly asked the reader to click Edit after clicking the radio button next to the alias. On the edit screen, there's no Additional Version section, but there is a dropdown for Weighted alias, so I suggest this change. I added backslashes before the < and > symbols because without the backslashes the Github markdown preview failed. This might not actually be necessary for the docs.aws markdown.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
