### PR TITLE
Add clarity for filenames for windows vs linux

### DIFF
--- a/doc_source/register-on-premises-instance-iam-user-arn.md
+++ b/doc_source/register-on-premises-instance-iam-user-arn.md
@@ -202,7 +202,7 @@ Add a configuration file to the on\-premises instance, using root or administrat
    + For Ubuntu Server: `/etc/codedeploy-agent/conf`
    + For Windows Server: `C:\ProgramData\Amazon\CodeDeploy`
 
-1. Use a text editor to add the following information to the newly created `codedeploy.onpremises.yml` (linux) or `conf.onpremises.yml` (windows) file:
+1. Use a text editor to add the following information to the newly created `codedeploy.onpremises.yml` (Linux) or `conf.onpremises.yml` (Windows) file:
 
    ```
    ---

--- a/doc_source/register-on-premises-instance-iam-user-arn.md
+++ b/doc_source/register-on-premises-instance-iam-user-arn.md
@@ -202,7 +202,7 @@ Add a configuration file to the on\-premises instance, using root or administrat
    + For Ubuntu Server: `/etc/codedeploy-agent/conf`
    + For Windows Server: `C:\ProgramData\Amazon\CodeDeploy`
 
-1. Use a text editor to add the following information to the newly created `codedeploy.onpremises.yml` or `conf.onpremises.yml` file:
+1. Use a text editor to add the following information to the newly created `codedeploy.onpremises.yml` (linux) or `conf.onpremises.yml` (windows) file:
 
    ```
    ---


### PR DESCRIPTION
This tripped me up for a while and this helps out

*Issue #, if available:*

*Description of changes:*
In a single location, add clarity for which filename to use for on-premises ec2 codedeploy depending on the OS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
