### PR TITLE
Update Path of Windows logs

### DIFF
--- a/doc_source/codedeploy-agent-operations-cloudwatch-agent.md
+++ b/doc_source/codedeploy-agent-operations-cloudwatch-agent.md
@@ -124,14 +124,14 @@ You can configure the CloudWatch agent by stepping through a wizard or by manual
                "files": {
                    "collect_list": [
                        {
-                           "file_path": "C:\\ProgramData\Amazon\CodeDeploy\log\codedeploy-agent-windows-log.txt",
+                           "file_path": "C:\\ProgramData\\Amazon\\CodeDeploy\\log\codedeploy-agent-log.txt",
                            "log_group_name": "codedeploy-agent-windows-log",
                            "log_stream_name": "{instance_id}-codedeploy-agent-windows-log"
                        },
                        {
-                           "file_path": "C:\\ProgramData\Amazon\CodeDeploy\deployment-logs\codedeploy-agent-windows-deployments.log",
+                           "file_path": "C:\\ProgramData\\Amazon\\CodeDeploy\\deployment-logs\\codedeploy-agent-deployments.log",
                            "log_group_name": "codedeploy-agent-windows-deployment-log",
-                           "log_stream_name": "{instance_id}-codedeploy-agent-windows-deployment-log"
+                           "log_stream_name": "{instance_id}-codedeploy-agent-deployment-log"
                        }
                    ]
                },

--- a/doc_source/codedeploy-agent-operations-cloudwatch-agent.md
+++ b/doc_source/codedeploy-agent-operations-cloudwatch-agent.md
@@ -124,7 +124,7 @@ You can configure the CloudWatch agent by stepping through a wizard or by manual
                "files": {
                    "collect_list": [
                        {
-                           "file_path": "C:\\ProgramData\\Amazon\\CodeDeploy\\log\codedeploy-agent-log.txt",
+                           "file_path": "C:\\ProgramData\\Amazon\\CodeDeploy\\log\\codedeploy-agent-log.txt",
                            "log_group_name": "codedeploy-agent-windows-log",
                            "log_stream_name": "{instance_id}-codedeploy-agent-windows-log"
                        },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates the path to reflect current location of deploy logs on windows agents. Per [these docs](https://docs.amazonaws.cn/en_us/codedeploy/latest/userguide/deployments-view-logs.html) and our own testing, the word `windows` is no longer in the default log path.

Also adds escaping for the full log path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
